### PR TITLE
Switch to using `inherit (expr) attr` and `let in` instead of `with` and `rec`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,8 +15,10 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    nvchad-starter.url = "github:NvChad/starter/main"; # people who want to use diffrent starter could override this.
-    nvchad-starter.flake = false;
+    nvchad-starter = {
+      url = "github:NvChad/starter/main"; # people who want to use a different starter could override this.
+      flake = false;
+    };
   };
 
   outputs =

--- a/nix/nvchad.nix
+++ b/nix/nvchad.nix
@@ -24,8 +24,15 @@
   extraPlugins ? "return {}",
   lazy-lock ? "",
 }:
-with lib;
-stdenvNoCC.mkDerivation rec {
+let
+  inherit (lib)
+    lists
+    makeBinPath
+    licenses
+    maintainers
+    ;
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "nvchad";
   version = "2.5";
   src = starterRepo;
@@ -78,7 +85,7 @@ stdenvNoCC.mkDerivation rec {
     install -Dm777 "$extraConfigFile" $out/config/lua/extraConfig.lua;
     mv $out/config/init.lua $out/config/lua/init.lua
     install -Dm777 $NewInitFile $out/config/init.lua
-    wrapProgram $out/bin/nvim --prefix PATH : '${makeBinPath nativeBuildInputs}'
+    wrapProgram $out/bin/nvim --prefix PATH : '${makeBinPath finalAttrs.nativeBuildInputs}'
     runHook postInstall
   '';
   postInstall = ''
@@ -98,4 +105,4 @@ stdenvNoCC.mkDerivation rec {
       bot-wxt1221
     ];
   };
-}
+})


### PR DESCRIPTION
This PR removes the usage of `rec` in the NvChad derivation. Furthermore, this PR switches from using expressions such as `with lib;` to `inherit (expr) attr` to increase readability.  Finally, removing `rec` allows for derivated attrs to be overriden as expected according to [#119942](https://github.com/NixOS/nixpkgs/pull/119942)