### PR TITLE
Make `chadrc.lua` configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,12 @@ Overriding the option will expand this list.
 
 The config written in lua. It will be loaded after nvchad loaded.
 
+#### chadrcConfig (optional)
+
+`string`
+
+Configuration that replaces chadrc.lua. Make sure to include `local M = {}` at the top, and `return M` at the bottom.
+
 ##### gcc (optional)
 
 `pkg.gcc`

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -25,6 +25,7 @@ let
     gcc_new = cfg.gcc;
     starterRepo = nvchad-starter;
     extraConfig = cfg.extraConfig;
+    chadrcConfig = cfg.chadrcConfig;
     lazy-lock = cfg.lazy-lock;
     extraPlugins = cfg.extraPlugins;
   };
@@ -70,6 +71,11 @@ in
       type = types.str;
       default = "";
       description = "These config are loaded after nvchad in the end of init.lua in starter";
+    };
+    chadrcConfig = mkOption {
+      type = types.str;
+      default = "";
+      description = "This config replaces the chadrc.lua file. Make sure to include `local M = {}` at the top, and `return M` at the bottom.";
     };
     gcc = mkOption {
       type = types.package;

--- a/nix/nvchad.nix
+++ b/nix/nvchad.nix
@@ -20,6 +20,7 @@
   tree-sitter,
   extraPackages ? [ ], # the default value is for import from flake.nix
   extraConfig ? "",
+  chadrcConfig ? "",
   starterRepo,
   extraPlugins ? "return {}",
   lazy-lock ? "",
@@ -30,6 +31,7 @@ let
     makeBinPath
     licenses
     maintainers
+    optionalString
     ;
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -53,6 +55,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     end
     return M1
   '';
+  NewChadrcFile = writeText "chadrc.lua" chadrcConfig;
   LockFile = writeText "lazy-lock.json" lazy-lock;
   nativeBuildInputs =
     (lists.unique (
@@ -77,6 +80,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     chmod 777 $out/config
     chmod 777 $out/config/lua # cp make it unwritable
     chmod 777 $out/config/lua/plugins
+    ${optionalString (chadrcConfig != "") "install -Dm777 $NewChadrcFile $out/config/lua/chadrc.lua"}
     mv $out/config/lua/plugins/init.lua $out/config/lua/plugins/init-1.lua
     install -Dm777 $extraPluginsFile $out/config/lua/plugins/init-2.lua
     install -Dm777 $NewPluginsFile $out/config/lua/plugins/init.lua


### PR DESCRIPTION
Adds a new configuration option, `chadrcConfig`, that overwrites the base `chadrc.lua` file. This if for defining configuration specific to nvchad.

This is already possible with `xdg.configFile."nvim/lua/chadrc.lua"`, but the `chadrc.lua` file is really integral to configuring nvchad, so it really should be included in `nix4nvchad`.

Currently it requires that the user defines `local M = {}` and `return M` in the config to match the original `chadrc.lua`. This makes sense in cases where you have a separate `chadrc.lua` file in your NixOS config, and use `builtins.readFile` to populate `chadrcConfig`, as you'd get the benefits of having a lua LSP. At the same time, for people defining the config directly in nix, it doesn't make much sense to be forced to include `local M = {}` etc. I'm not quite sure what the best way to handle this is.