### PR TITLE
fix: correct binary name in flake app definition (fixes #240)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,10 @@
         };
         apps = rec {
           nvchad =
-            flake-utils.lib.mkApp { drv = self.packages.${system}.nvchad; }
+            flake-utils.lib.mkApp { 
+              drv = self.packages.${system}.nvchad;
+              name = "nvim";
+            }
             # ? workaround add meta attrs to avoid warning message
             // {
               meta = self.packages.${system}.nvchad.meta;


### PR DESCRIPTION
### Problem
Fixes #240 where running `nix run github:nix-community/nix4nvchad/#nvchad` resulted in error:
```
error: unable to execute '/nix/store/.../bin/nvchad': No such file or directory
```

### Root Cause
The `nvchad.nix` package creates the binary as `$out/bin/nvim` (standard Neovim binary name), but the `flake.nix` `mkApp` definition was incorrectly looking for a binary named `nvchad`.

### Solution
Updated the `mkApp` definition in `flake.nix` to use the correct binary name:
```nix
nvchad = flake-utils.lib.mkApp {
  drv = self.packages.${system}.nvchad;
  name = "nvim";  # Correct binary name
};
```

### Testing
- ✅ `nix run github:MOIS3Y/nix4nvchad/hotfix#nvchad` now works correctly
- ✅ Neovim with NvChad configuration launches properly
- ✅ Binary is accessible at the expected path `/nix/store/.../bin/nvim`

### Impact
- Resolves the immediate startup issue for users
- Maintains standard Neovim binary naming convention
- No breaking changes to existing functionality