### PR TITLE
refactor(bin): fix shellcheck issues and improve script structure

### DIFF
--- a/bin/nvchad.sh
+++ b/bin/nvchad.sh
@@ -1,6 +1,6 @@
-# █▄░█ █░█ █ █▀▄▀█   █░█░█ █▀█ ▄▀█ █▀█ █▀█ █▀▀ █▀█ ▀
-# █░▀█ ▀▄▀ █ █░▀░█   ▀▄▀▄▀ █▀▄ █▀█ █▀▀ █▀▀ ██▄ █▀▄ ▄
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # INIT GLOBAL VARIABLES:
 _CONF_HOME="${HOME}/.config"
@@ -9,25 +9,22 @@ _CONF_FILE="${_CONF_DIR}/init.lua"
 
 
 init_config() {
-    local nvchad_bin="$(readlink -f $0)"
-    local store_path="$(dirname ${nvchad_bin%/*})"
-    local backup="${_CONF_HOME}/nvim_$(date +'%Y_%m_%d_%H_%M_%S').bak"
+    local nvchad_bin
+    nvchad_bin="$(readlink -f "$0")"
+    local store_path
+    store_path="$(dirname "${nvchad_bin%/*}")"
+    local backup
+    backup="${_CONF_HOME}/nvim_$(date +'%Y_%m_%d_%H_%M_%S').bak"
 
     if [ -d "$_CONF_DIR" ]; then
-        mv $_CONF_DIR $backup
-        mkdir -p $_CONF_DIR
-    else
-        mkdir -p $_CONF_DIR
+        mv "$_CONF_DIR" "$backup"
     fi
-    
-    cp -r $store_path/config/* $_CONF_DIR
-    for file_or_dir in $(find "$_CONF_DIR"); do
-        if [ -d "$file_or_dir" ]; then
-            chmod 755 $file_or_dir
-        else
-            chmod 664 $file_or_dir
-        fi
-    done
+    mkdir -p "$_CONF_DIR"
+
+    cp -r "$store_path/config/"* "$_CONF_DIR"
+
+    find "$_CONF_DIR" -type d -exec chmod 755 {} +
+    find "$_CONF_DIR" -not -type d -exec chmod 664 {} +
 }
 
 
@@ -39,17 +36,22 @@ check_init() {
 
 
 wrapper() {
-    nvim -u $_CONF_FILE "$@"
+    nvim -u "$_CONF_FILE" "$@"
+}
+
+
+cleanup_lock() {
+    if ! [ -s "${_CONF_DIR}/lazy-lock.json" ]; then
+        if [ -e "${_CONF_DIR}/lazy-lock.json" ]; then
+            rm "$_CONF_DIR/lazy-lock.json"
+        fi
+    fi
 }
 
 
 main() {
     check_init
-    if ! [ -s "${_CONF_DIR}/lazy-lock.json" ]; then
-      if [ -e "${_CONF_DIR}/lazy-lock.json" ]; then
-        rm "$_CONF_DIR/lazy-lock.json" 
-      fi
-    fi
+    cleanup_lock
     wrapper "$@"
 }
 


### PR DESCRIPTION
- Added shebang and 'set -euo pipefail' for better reliability.
- Properly quoted all variables to prevent word splitting.
- Separated local variable declaration and assignment.
- Replaced fragile find loop with efficient '-exec chmod {} +' calls.
- Extracted lockfile cleanup logic into a dedicated 'cleanup_lock' function.
- Refactored 'main' to act as a clean orchestrator.