### PR TITLE
docs: migrate to mdBook and rewrite README

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build mdBook
+        run: nix develop --command mdbook build docs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: 'docs/book'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
-**/result
+# Nix
+result
+result-*
+.direnv/
+
+# Documentation
+docs/book/

--- a/README.md
+++ b/README.md
@@ -1,401 +1,50 @@
-# NvChad on Nix
+# nix4nvchad
 
-![logo](https://nvchad.com/screenshots/onedark.webp)
+**A seamless way to integrate NvChad, a blazing fast Neovim configuration, into your Nix setup.**
 
-## What is it?
+`nix4nvchad` provides a declarative, reproducible way to install and configure [NvChad](https://nvchad.com/) using Nix flakes. It safely manages NvChad's runtime state by automatically provisioning its configuration directory while keeping your system environment clean by injecting LSP servers and tools exclusively into the Neovim wrapper.
 
-The repository contains nix flake to install the [NvChad](https://nvchad.com/)
-configuration on any system that uses `Nix` and `nix flakes`.
+<div align="center">
 
-### Flake contains:
+[![Docs](https://img.shields.io/badge/docs-latest-blue?style=for-the-badge&labelColor=101418)](https://nix-community.github.io/nix4nvchad/)
+![NixOS](https://img.shields.io/badge/NixOS-5277C3?style=for-the-badge&logo=nixos&logoColor=white&labelColor=101418)
+![Neovim](https://img.shields.io/badge/Neovim-57A143?style=for-the-badge&logo=neovim&logoColor=white&labelColor=101418)
+![Lua](https://img.shields.io/badge/Lua-2C2D72?style=for-the-badge&logo=lua&logoColor=white&labelColor=101418)
+[![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=for-the-badge&labelColor=101418)](./LICENSE)
 
-- nvchad package
-- home-manager module
+<br>
 
-You can choose any of the presented methods to install NvChad.
+<img src="https://nvchad.com/screenshots/onedark.webp" width="80%" alt="NvChad Screenshot">
 
+</div>
 
-<details>
-  <summary> <b>General notes</b> </summary>
-  <br/>
-  
-  NvChad itself is not an executable file, it is a perfect configuration for [Neovim](https://neovim.io/).
+## Key Features
 
-  Unfortunately there is no easy way to add it to `/nix/store`
-  More precisely, it’s easy to add it, but it won’t work, at least for now (version 2.5)
+- **Home Manager Integration:** Easily configure NvChad using our provided Home Manager module.
+- **Standalone Package:** Use it independently of Home Manager by overriding the Nix derivation directly.
+- **Isolated Dependencies:** Manage your runtime dependencies (like LSP servers, formatters, and tools) in isolation. They are made available exclusively to NvChad without polluting your global `$PATH`.
+- **Custom Starter:** Swap the default starter repository with your own fork to maintain pure, vanilla Lua configuration while leveraging Nix for dependencies.
 
-  This is due to the fact that by default `neovim` reads 
-  the file `~/.config/nvim/init.lua` and starts.
-  NvChad lazily loads plugins and on first load, `lazyvim` will save
-  `lazy-lock.json` next to `~/.config/nvim/init.lua`
-  As you understand, this is not a problem for any distribution and it 
-  does not violate the principles of [The Twelve Factor App](https://12factor.net/config)
-  because, as already said, NvChad is a configuration and not a package with an application.
-  But with Nix the problem is /nix/store is a read-only system,
-  the source code trying to write a file or change the current one will result in an error.
-  There will also be a problem with the ability to change the configuration
-  on the fly, since this changes the `chadrc.lua` file
+## Quick Try
 
-  The method We used to solve this problem (home-manager module) is a hack.
-  Don't worry, it doesn't break anything, but it doesn't follow the basic
-  principle of how home-manager adds configuration files to the user's home directory.
-  Absolutely all configuration files are stored in `/nix/store/`
-  By default, the home manager creates symbolic links from `/nix/store/` to the user's home directory.
-  This ensures that configuration changes after the next generation build are available to the user.
-
-  In addition, if you have ever created a declarative configuration
-  for vanilla `neovim` you know that plugins are also stored in `/nix/store/`
-  NvChad installs plugins in `~/.local/share/nvim/`.
-  This is not a problem for us, they are still immutable until you explicitly update them.
-  If your own NvChad configuration which you pass
-  to the module as `config.programs.nvchad.extraConfig`
-  contains `lazy-lock.json` specific plugin versions will be installed.
-
-  Here's everything you need to know before you start using NvChad with Nix
-  If you still need to add NvChad to your configuration, welcome!
-</details>
-
-
-## How it works?
-
-- you add this repository as `inputs` to flake.nix of your configuration
-- you add a package with `NvChad` to your configuration as an overlay or as a `home-manager` module
-- specify extraPackages and extraConfig for the package or module
-- you are building a new system generation
-- as a result, you will receive an executable file `nvim`, nvim.desktop to launch from the launcher and your own configuration overlay if you passed extraConfig
-- each extraPackages is available to NvChad, if this is for example an LSP server, NvChad will find its executable file
-- extraPackages are not available globally, they are only available in the NvChad scope
-- if you do not pass any parameters only `extraPackages` for starter configuration are included
-
-
-# Quick use without installation to try
+Want to see it in action without installing? You can run it directly:
 
 ```console
-nix run github:nix-community/nix4nvchad/#nvchad
+nix run github:nix-community/nix4nvchad
 ```
 
-> [!WARNING]
-> Run the command above if you are not using your `neovim` configuration!
-> - If you already have a `neovim` configuration in `~/.config/nvim` and `init.lua` is present there
-> nvchad will not copy the configuration to the home directory and will probably not start correctly
-> - If there is no `init.lua` in `~/.config/nvim` but there are any other files, this will overwrite
-> `~/.config/nvim` with the `NvChad starter` configuration
-> - Your current configuration will be saved in `~/.config/nvim/nvim_%Y_%m_%d_%H_%M_%S.bak`
+> [!WARNING]  
+> If you already have an existing Neovim configuration at `~/.config/nvim`, this command will create a backup before launching. Make sure your environment is safe.
 
+## Usage Guide
 
-# Installation
+Comprehensive guides on installation, configuration, and advanced usage are available in the official **[Documentation](https://nix-community.github.io/nix4nvchad/)**.
 
-To install it you **must have flake enabled** and your NixOS configuration
-**must be managed with flakes.** See [Flakes](https://wiki.nixos.org/wiki/Flakes) for
-instructions on how to install and enable them on NixOS.
+### Table of Contents
+- [Installation](https://nix-community.github.io/nix4nvchad/installation.html)
+- [Configuration Options](https://nix-community.github.io/nix4nvchad/configuration.html)
+- [Advanced Usage](https://nix-community.github.io/nix4nvchad/advanced_usage.html)
 
-### First step
+## License
 
-You can add this flake as inputs in `flake.nix` in the repository
-containing your NixOS configuration:
-
-```nix
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    home-manager = {
-      url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    # ...
-    nix4nvchad = {
-      url = "github:nix-community/nix4nvchad";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    # ...
-  };
-```
-
-This flake provides an overlay for Nixpkgs, with package and a home-manager module.
-
-They are respectively found in the flake as
-
-- `inputs.nix4nvchad.packages.${system}.default`
-- `inputs.nix4nvchad.packages.${system}.nvchad`
-
-
-- `inputs.nix4nvchad.homeManagerModules.default`
-- `inputs.nix4nvchad.homeManagerModules.nvchad`
-- `inputs.nix4nvchad.homeManagerModule`
-
-(Where `${system}` is either `x86_64-linux` `aarch64-linux` `x86_64-darwin` `aarch64-darwin`)
-
-### Second step
-
-Output data can be added in different ways, for example this is how I do it for NixOS:
-
-In the example below, the home manager is installed as a NixOS module
-
-```nix
-  outputs = { self, nixpkgs, home-manager, ... }@inputs:
-    let
-      system = "x86_64-linux";
-      lib = nixpkgs.lib;
-      extraSpecialArgs = { inherit system inputs; };  # <- passing inputs to the attribute set for home-manager
-      specialArgs = { inherit system inputs; };       # <- passing inputs to the attribute set for NixOS (optional)
-    in {
-    nixosConfigurations = {
-      dummy-host = lib.nixosSystem {
-        specialArgs = {
-          inherit system inputs;           # <- this will make inputs available anywhere in the NixOS configuration
-        };
-        modules = [
-          ./path/to/configuration.nix
-          home-manager.nixosModules.home-manager {
-            home-manager = {
-              extraSpecialArgs = {
-                inherit system inputs;     # <- this will make inputs available anywhere in the HM configuration
-              };
-              useGlobalPkgs = true;
-              useUserPackages = true;
-              users.dummyUserName = import ./path/to/home.nix;
-            };
-          }
-        ];
-      };
-    };
-  };
-```
-
-If you are new to NixOS here is a useful channel [Vimjoyer](https://www.youtube.com/watch?v=rEovNpg7J0M)
-
-
-### Third step (optional)
-
-All we have to do is add `nvchad` to the list of available packages using overlays
-
-Somewhere in your `configuration.nix`
-
-```nix
-{ config, pkgs, inputs, ... }: {  # <-- inputs from flake
-  # ...
-  nixpkgs = { 
-    overlays = [
-      (final: prev: {
-        nvchad = inputs.nix4nvchad.packages."${pkgs.system}".nvchad;
-      })
-    ];
-  };
-  # ...
-}
-```
-
-Now you can call the package anywhere as a package from nixpkgs
-
-- `pkgs.nvchad`
-
-Examples:
-- `environment.systemPackages = [ pkgs.nvchad ];` NixOS
-- `users.users.<name>.packages = [ pkgs.nvchad ];` NixOS
-- `home.packages = with pkgs; [ pkgs.nvchad ];`  home-manager
-
-# Configuration
-
-Depending on which usage method you choose, take a look at a couple of snippets:
-
-### home-manager module
-
-Somewhere in your `home.nix` or a separate module:
-
-Default:
-
-```nix
-{ inputs, config, pkgs, ... }: {
-  imports = [
-    inputs.nix4nvchad.homeManagerModule
-  ];
-  programs.nvchad.enable = true;
-}
-```
-
-Or with customization of options:
-
-
-```nix
-{ inputs, config, pkgs, ... }: {
-  imports = [
-    inputs.nix4nvchad.homeManagerModule
-  ];
-  programs.nvchad = {
-    enable = true;
-    extraPackages = with pkgs; [
-      nodePackages.bash-language-server
-      docker-compose-language-service
-      dockerfile-language-server-nodejs
-      emmet-language-server
-      nixd
-      (python3.withPackages(ps: with ps; [
-        python-lsp-server
-        flake8
-      ]))
-    ];
-    hm-activation = true;
-    backup = true;
-  };
-}
-```
-
-### Available options:
-
-- [enable](#enable)
-- [neovim](#neovim)
-- [extraPlugins](#extraPlugins)
-- [extraPackages](#extraPackages)
-- [extraConfig](#extraConfig)
-- [gcc](#gcc)
-- [lazy-lock](#lazy-lock)
-- [hm-activation](#hm-activation)
-- [backup](#backup)
-
-All options are not required
-
-##### enable
-
-`true` or `false`
-
-If false ignore this module when build new generation
-
-##### neovim
-
-`pkgs.neovim`
-
-Neovim package for use under nvchad wrapper
-
-##### extraPlugins
-
-```lua
-return {
-  {"equalsraf/neovim-gui-shim",lazy=false},
-  {"lervag/vimtex",lazy=false},
-  {"nvim-lua/plenary.nvim"},
-  {
-    'xeluxee/competitest.nvim',
-    dependencies = 'MunifTanjim/nui.nvim',
-    config = function() require('competitest').setup() end,
-  },
-}
-```
-
-The extra plugins you want to install. Loaded by lazy.nvim
-
-##### extraPackages
-
-`[]` list of pkgs
-
-List of additional packages available for NvChad as runtime dependencies
-NvChad extensions assume that the libraries it need
-will be available globally.
-By default, all dependencies for the starting configuration are included.
-Overriding the option will expand this list.
-
-##### extraConfig
-
-`string`
-
-The config written in lua. It will be loaded after nvchad loaded.
-
-#### chadrcConfig (optional)
-
-`string`
-
-Configuration that replaces `chadrc.lua.` Make sure to include `local M = {}` at the top, and `return M` at the bottom.
-
-##### gcc
-
-`pkg.gcc`
-
-The gcc compiler you want to use.
-
-##### lazy-lock
-
-`string`
-
-A json file. Which is in ~/.config/nvim/lazy-lock.json to lock lazy.nvim's plugin.
-
-Leave it as "" if don't want it.
-
-##### hm-activation
-
-`true` or `false`
-
-It's a trick
-If you do not want home-manager to manage nvchad configuration, 
-set the false option. In this case, HM will not copy the configuration
-saved in /nix/store to ~/.config/nvim.
-This way you can customize the configuration in the usual way
-by cloning it from the NvChad repository.
-By default, the ~/.config/nvim is managed by HM.
-
-##### backup
-
-`true` or `false`
-
-Since the module violates the principle of immutability
-and copies NvChad to `~/.config/nvim` rather than creating
-a symbolic link by default, it will create a backup copy of
-`~/.config/nvim_%Y_%m_%d_%H_%M_%S.bak` when each generation.
-This ensures that the module
-will not delete the configuration accidentally.
-You probably do not need backups, just disable them
-`config.programs.nvchad.backup = false;`
-
-
-# Usage
-
-Whichever method you choose, after installation you'll probably want to run `NvChad`.  
-Using the `nvim` wrapper executable it will be automatically available in your `$PATH`.  
-You can also launch through the application manager (rofi, wofi, etc).  
-The package comes with `nvim.desktop`.  
-
-If you are not using the HM module or have disabled `hm-activation`:
-- `NvChad` expects `~/.config/nvim/init.lua` to be available at startup
-- if the file does not exist, `NvChad` will copy it and all files from `/nix/store/hash-nvchad-2.5/config`
-- this will be either your configuration or starter
-- if `~/.config/nvim/` is not empty `NvChad` will create a backup copy nearby
-
-#### Note!
-
-If you are using the NvChad home-manager module, do not add neovim from the standard module:
-
-```nix
-programs.neovim.enable = true;
-```
-Also, do not add neovim as a package to the configuration:
- ```nix
-home.packages = [ pkgs.neovim ];
-```
-
-# Use your own NvChad configuration
-
-You can use your own NvChad configuration by providing your own repository or local folder.  
-It has to follow the structure of [the NvChad starter](https://github.com/NvChad/starter) (a fork or local copy).  
-
-```nix
-  inputs = {
-    # Default:
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    home-manager = {
-      url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    # adding the starter input here
-    nvchad-starter = {
-      url = "github.com:<github-username>/<repository-name>"; # <- replace this with your own
-      # url = "path:<local_path>" # <- for local relative folder (e.g. path:./home/nvim) 
-      flake = false;
-    }
-
-    nix4nvchad = {
-      url = "github:nix-community/nix4nvchad";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nvchad-starter.follows = "nvchad-starter"; # <- overwrite the module input here
-    };
-  };
-```
-
-And follow above steps.
+This project is licensed under the **GPL-3.0** License.

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,14 @@
+[book]
+authors = [
+    "MOIS3Y"
+]
+language = "en"
+src = "src"
+title = "NvChad on Nix Documentation"
+
+[output.html]
+git-repository-url = "https://github.com/nix-community/nix4nvchad"
+edit-url-template = "https://github.com/nix-community/nix4nvchad/edit/main/docs/{path}"
+preferred-dark-theme = "macchiato"
+additional-css = ["theme/catppuccin.css"]
+theme = "theme"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,9 @@
+# Summary
+
+- [Introduction](introduction.md)
+- [Installation](installation.md)
+- [Configuration](configuration.md)
+- [Advanced Usage](advanced_usage.md)
+
+---
+- [Deprecated](deprecated.md)

--- a/docs/src/advanced_usage.md
+++ b/docs/src/advanced_usage.md
@@ -1,0 +1,63 @@
+# Advanced Usage
+
+## Overriding the Starter Repository
+
+By default, `nix4nvchad` pulls the [NvChad starter template](https://github.com/NvChad/starter) to initialize the configuration. This provides a minimal, fast setup out-of-the-box.
+
+> [!IMPORTANT]
+> If you have your own fork of the starter repository or a completely customized NvChad structure, you can override the source used to build the derivation. Your repository or local folder **must** follow the structure of the official NvChad starter.
+
+**Benefits of a Custom Starter:**
+1. **Portability:** You can maintain your Neovim configuration in pure, vanilla Lua. This means you can clone and use your configuration on any machine or distribution, even if it doesn't have Nix installed.
+2. **Minimal Nix Config:** Your Nix configuration remains incredibly clean. You only need to declare `nix4nvchad` and populate `extraPackages` to guarantee that Neovim can find the executables for your LSPs, formatters, and linters.
+
+### Defining the Custom Source
+
+You can override the source by defining it in your `flake.nix` inputs. This can be a GitHub repository or a local path on your machine.
+
+**Example (GitHub Repository):**
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    
+    # Your custom NvChad configuration repository
+    my-nvchad-config = {
+      url = "github:YOUR_USERNAME/my-nvchad-config";
+      flake = false;
+    };
+
+    nix4nvchad = {
+      url = "github:nix-community/nix4nvchad";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nvchad-starter.follows = "my-nvchad-config"; # Overrides the starter
+    };
+  };
+  # ...
+}
+```
+
+**Example (Local Folder):**
+If you manage your dotfiles in a single repository and want to point to a local `nvim` folder:
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    
+    # Path to your local nvim configuration folder
+    my-nvchad-config = {
+      url = "path:./path/to/your/nvim/folder";
+      flake = false;
+    };
+
+    nix4nvchad = {
+      url = "github:nix-community/nix4nvchad";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nvchad-starter.follows = "my-nvchad-config"; # Overrides the starter
+    };
+  };
+  # ...
+}
+```
+
+Once the input is overridden, `nix4nvchad` will automatically use your custom Lua files to build the wrapped Neovim derivation.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,0 +1,260 @@
+# Configuration
+
+Whether you use the Home Manager module or the package override, you can customize your NvChad experience by passing extra configurations, plugins, and packages. 
+
+When using Home Manager, these are set under `programs.nvchad.<option>`. When using the standalone package, they are passed as arguments to the `.override { ... }` function.
+
+## Available Options
+
+Below is a comprehensive list of available options grouped by their purpose. 
+
+> [!NOTE]
+> Options marked with **(HM)** in their description (`enable`, `hm-activation`, `backup`) are only applicable when using the Home Manager module. They have no effect when using the standalone package `.override`.
+
+---
+
+### Core & Environment
+
+This section covers options that affect the underlying Neovim executable and the tools available in its environment.
+
+#### `neovim`
+**Type:** `package`  
+**Default:** `pkgs.neovim`
+
+The Neovim package to use under the NvChad wrapper. You can use this to switch to a nightly build or a custom-compiled version of Neovim.
+
+**Example (Home Manager):**
+```nix
+programs.nvchad.neovim = pkgs.neovim-unwrapped;
+```
+
+**Example (Standalone):**
+```nix
+nvchad = inputs.nix4nvchad.packages.${system}.default.override {
+  neovim = pkgs.neovim-unwrapped;
+};
+```
+
+#### `extraPackages`
+**Type:** `list of packages`  
+**Default:** `[ ]` (plus default starter dependencies)
+
+A list of additional packages (like LSPs, formatters, linters) to make available to NvChad as runtime dependencies. 
+
+> [!TIP]
+> Keep your global environment clean! Add tools like LSPs (e.g., `pyright`, `nil`, `gopls`) here. They will only be available within the NvChad environment, ensuring your editor finds them without polluting your system.
+
+**Example (Home Manager):**
+```nix
+programs.nvchad.extraPackages = with pkgs; [
+  ripgrep
+  lua-language-server
+  stylua
+  nodePackages.bash-language-server
+];
+```
+
+**Example (Standalone):**
+```nix
+nvchad = inputs.nix4nvchad.packages.${system}.default.override {
+  extraPackages = with pkgs; [
+    ripgrep
+    lua-language-server
+    stylua
+    nodePackages.bash-language-server
+  ];
+};
+```
+
+#### `gcc`
+**Type:** `package`  
+**Default:** `pkgs.gcc`
+
+The GCC compiler you want to use. Tree-sitter relies heavily on a C compiler to build parsers. You can override this if you need a specific compiler toolchain.
+
+**Example (Home Manager):**
+```nix
+programs.nvchad.gcc = pkgs.gcc13;
+```
+
+**Example (Standalone):**
+```nix
+nvchad = inputs.nix4nvchad.packages.${system}.default.override {
+  gcc = pkgs.gcc13;
+};
+```
+
+---
+
+### Customization & Plugins
+
+This section covers options for injecting custom Lua code, modifying the UI, and managing plugins.
+
+#### `extraConfig`
+**Type:** `string`  
+**Default:** `""`
+
+Arbitrary Lua code that will be loaded *after* NvChad is fully loaded. Use this to set custom `vim.opt` settings, keymaps, or auto-commands.
+
+> [!CAUTION]
+> If you have a very complex configuration, writing massive multiline strings in Nix can become hard to maintain. Consider splitting them out into separate `.lua` files and reading them with `builtins.readFile`.
+
+**Example (Home Manager):**
+```nix
+programs.nvchad.extraConfig = ''
+  -- Custom vim options
+  vim.opt.shiftwidth = 2
+  vim.opt.tabstop = 2
+  vim.opt.expandtab = true
+  
+  -- Custom keymaps
+  vim.keymap.set("n", "<leader>w", "<cmd>w<CR>", { desc = "Save file" })
+'';
+```
+
+**Example (Standalone):**
+```nix
+nvchad = inputs.nix4nvchad.packages.${system}.default.override {
+  extraConfig = ''
+    -- Custom vim options
+    vim.opt.shiftwidth = 2
+    vim.opt.tabstop = 2
+    vim.opt.expandtab = true
+    
+    -- Custom keymaps
+    vim.keymap.set("n", "<leader>w", "<cmd>w<CR>", { desc = "Save file" })
+  '';
+};
+```
+
+#### `chadrcConfig`
+**Type:** `string`  
+**Default:** `""`
+
+Configuration that replaces `chadrc.lua`. This is primarily used to override the default UI configuration (themes, transparency, etc.). 
+
+> [!IMPORTANT]
+> Make sure to include `local M = {}` at the top, and `return M` at the bottom of your string.
+
+**Example (Home Manager):**
+```nix
+programs.nvchad.chadrcConfig = ''
+  local M = {}
+  M.ui = {
+    theme = "catppuccin",
+    transparency = true,
+  }
+  return M
+'';
+```
+
+**Example (Standalone):**
+```nix
+nvchad = inputs.nix4nvchad.packages.${system}.default.override {
+  chadrcConfig = ''
+    local M = {}
+    M.ui = {
+      theme = "catppuccin",
+      transparency = true,
+    }
+    return M
+  '';
+};
+```
+
+#### `extraPlugins`
+**Type:** `string` (Lua code)  
+**Default:** `""`
+
+A string containing a Lua table of extra plugins you want to install. This list will be loaded and managed by `lazy.nvim`.
+
+**Example (Home Manager):**
+```nix
+programs.nvchad.extraPlugins = ''
+  return {
+    { "equalsraf/neovim-gui-shim", lazy = false },
+    { "nvim-lua/plenary.nvim" },
+    {
+      "xeluxee/competitest.nvim",
+      dependencies = "MunifTanjim/nui.nvim",
+      config = function() require("competitest").setup() end,
+    },
+  }
+'';
+```
+
+**Example (Standalone):**
+```nix
+nvchad = inputs.nix4nvchad.packages.${system}.default.override {
+  extraPlugins = ''
+    return {
+      { "equalsraf/neovim-gui-shim", lazy = false },
+      { "nvim-lua/plenary.nvim" },
+      {
+        "xeluxee/competitest.nvim",
+        dependencies = "MunifTanjim/nui.nvim",
+        config = function() require("competitest").setup() end,
+      },
+    }
+  '';
+};
+```
+
+#### `lazy-lock`
+**Type:** `string` (JSON content)  
+**Default:** `""`
+
+The contents of a `lazy-lock.json` file. If provided, this will lock `lazy.nvim`'s plugin versions to ensure reproducible plugin installations. Leave it empty if you want `lazy.nvim` to manage the lockfile dynamically in your home directory.
+
+**Example (Home Manager):**
+```nix
+programs.nvchad.lazy-lock = builtins.readFile ./lazy-lock.json;
+```
+
+**Example (Standalone):**
+```nix
+nvchad = inputs.nix4nvchad.packages.${system}.default.override {
+  lazy-lock = builtins.readFile ./lazy-lock.json;
+};
+```
+
+---
+
+### Home Manager Specifics
+
+These options dictate how the Home Manager module behaves when activating the configuration.
+
+#### `enable`
+**Type:** `boolean`  
+**Default:** `false`
+
+**(HM)** Enables the NvChad Home Manager module. If set to `false`, the module is ignored when building the new generation.
+
+**Example:**
+```nix
+programs.nvchad.enable = true;
+```
+
+#### `hm-activation`
+**Type:** `boolean`  
+**Default:** `true`
+
+**(HM)** If set to `false`, Home Manager will **not** automatically copy the NvChad configuration to `~/.config/nvim`. This allows you to manage the configuration directory manually (e.g., by cloning the NvChad repository yourself) while still using the wrapped executable and isolated dependencies provided by this module.
+
+**Example:**
+```nix
+programs.nvchad.hm-activation = false;
+```
+
+#### `backup`
+**Type:** `boolean`  
+**Default:** `true`
+
+**(HM)** Because this module copies NvChad to `~/.config/nvim` instead of creating a read-only symlink (a necessary workaround for NvChad's lazy-loading), it will create a backup of your existing configuration at `~/.config/nvim_%Y_%m_%d_%H_%M_%S.bak` during generation switches. 
+
+If you do not want backups to be created, disable this option.
+
+**Example:**
+```nix
+programs.nvchad.backup = false;
+```

--- a/docs/src/deprecated.md
+++ b/docs/src/deprecated.md
@@ -1,0 +1,39 @@
+# Deprecated Features
+
+This page lists features, attributes, or configuration options that are currently deprecated and slated for removal in future versions of `nix4nvchad`.
+
+## `homeManagerModule` Attribute
+
+The flake output attribute `inputs.nix4nvchad.homeManagerModule` is **deprecated** and will be removed in the near future. 
+
+### Why is it being removed?
+
+In the Nix flake ecosystem, Home Manager modules exported by a flake are inherently non-standard (unlike NixOS or nix-darwin modules). The standard and most widely accepted way to export these is under the `homeManagerModules` (plural) attribute, typically exposing the default module as `homeManagerModules.default`.
+
+Maintaining the singular `homeManagerModule` attribute is redundant, creates unnecessary aliases in the flake output, and can trigger validation warnings in some Nix checking tools.
+
+### What should you use instead?
+
+You should update your imports to use the standard `homeManagerModules.default` path.
+
+**❌ Deprecated:**
+```nix
+{ inputs, pkgs, ... }: {
+  imports = [
+    inputs.nix4nvchad.homeManagerModule
+  ];
+  
+  programs.nvchad.enable = true;
+}
+```
+
+**✅ Recommended:**
+```nix
+{ inputs, pkgs, ... }: {
+  imports = [
+    inputs.nix4nvchad.homeManagerModules.default
+  ];
+  
+  programs.nvchad.enable = true;
+}
+```

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,0 +1,193 @@
+# Installation
+
+To install and use `nix4nvchad`, you must have Nix flakes enabled on your system. 
+
+There are two primary ways to integrate `nix4nvchad` into your setup: using the provided **Home Manager module** or using the **Standalone Package**.
+
+## Setting up Inputs
+
+First, you need to add the repository to your `flake.nix` inputs. 
+
+You can use the default configuration which automatically pulls the standard NvChad starter repository, or you can override it to use your own fork or local configuration folder.
+
+**Default Input:**
+
+> [!NOTE]
+> The default configuration pulls the standard [NvChad starter template](https://github.com/NvChad/starter). This is a minimal, blazing-fast setup. It's especially useful for servers or lightweight environments where you just want a solid Neovim base without writing custom plugins.
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    
+    nix4nvchad = {
+      url = "github:nix-community/nix4nvchad";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+  # ...
+}
+```
+
+**Input with Custom Starter Repository:**
+
+If you have a customized NvChad setup that follows the structure of the starter template, you can override the `nvchad-starter` input. This tells the flake to build NvChad using your source instead of the default.
+
+> [!TIP]
+> **Why do this?** Keeping your NvChad configuration in a separate repository using vanilla Lua allows you to use the exact same configuration on systems without Nix. In your Nix configuration, you only need to enable `nix4nvchad` and pass `extraPackages` to ensure all LSPs and tools are perfectly wired up. See [Advanced Usage](advanced_usage.md#overriding-the-starter-repository) for more details.
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    
+    # Your custom NvChad configuration repository or local folder
+    my-nvchad-config = {
+      url = "github:YOUR_USERNAME/your-nvchad-repo";
+      # Or for a local folder: url = "path:./nvim-config";
+      flake = false;
+    };
+
+    nix4nvchad = {
+      url = "github:nix-community/nix4nvchad";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nvchad-starter.follows = "my-nvchad-config"; # Overrides the starter
+    };
+  };
+  # ...
+}
+```
+
+## Configuring Outputs
+
+Once your inputs are set, you need to make `nix4nvchad` available in your outputs. You can access the package or module directly by its path, or by passing `inputs` into your NixOS/Home Manager configuration.
+
+**Example 1: Passing `inputs` to a NixOS Module (with Home Manager):**
+```nix
+  outputs = { self, nixpkgs, home-manager, ... }@inputs: 
+  let
+    system = "x86_64-linux";
+  in
+  {
+    nixosConfigurations.my-system = nixpkgs.lib.nixosSystem {
+      inherit system;
+      # Makes 'inputs' available in NixOS configuration.nix
+      specialArgs = { inherit inputs; }; 
+      modules = [
+        ./configuration.nix
+        home-manager.nixosModules.home-manager {
+          # Makes 'inputs' available in Home Manager home.nix
+          home-manager.extraSpecialArgs = { inherit inputs; };
+          home-manager.users.myuser = import ./home.nix;
+        }
+      ];
+    };
+  };
+```
+
+**Example 2: Passing `inputs` for Standalone Home Manager (or nix-darwin):**
+```nix
+  outputs = { self, nixpkgs, home-manager, ... }@inputs: 
+  let
+    system = "aarch64-darwin"; # Or x86_64-linux
+    pkgs = import nixpkgs { inherit system; };
+  in
+  {
+    homeConfigurations."myuser" = home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+      # Makes 'inputs' available in home.nix
+      extraSpecialArgs = { inherit inputs; };
+      modules = [ ./home.nix ];
+    };
+  };
+```
+
+## Method 1: Home Manager Module (Recommended)
+
+If you use Home Manager, you can simply import the module.
+
+> [!WARNING]
+> **Do not install the standard `neovim` package and `nix4nvchad` at the same time.** 
+> `nix4nvchad` wraps the `nvim` executable and exposes it to the system. If you enable both the Home Manager `programs.neovim` module (or install `pkgs.neovim` globally) and `nvchad`, it will lead to an executable collision. Even if it installs, whichever `nvim` binary appears first in your `$PATH` will take precedence, resulting in undefined behavior and failing plugins.
+
+**❌ WRONG:**
+```nix
+{ inputs, pkgs, ... }: {
+  imports = [ inputs.nix4nvchad.homeManagerModules.default ];
+
+  programs.nvchad.enable = true;
+  programs.neovim.enable = true; # Collision!
+  home.packages = [ pkgs.neovim ]; # Collision!
+}
+```
+
+**✅ CORRECT:**
+```nix
+{ inputs, pkgs, ... }: {
+  imports = [ inputs.nix4nvchad.homeManagerModules.default ];
+
+  programs.nvchad = {
+    enable = true;
+    # You can configure extra options here (see the Configuration section)
+  };
+}
+```
+
+## Method 2: Standalone Package
+
+If you do not use Home Manager or prefer to handle the package directly, you can access the derivation from the flake outputs. 
+
+You can use the package as-is if you rely entirely on a custom starter repository (defined in inputs) or just want the default setup.
+
+```nix
+{ inputs, pkgs, ... }:
+let
+  system = pkgs.stdenv.hostPlatform.system;
+in
+{
+  environment.systemPackages = [ inputs.nix4nvchad.packages.${system}.default ];
+}
+```
+
+### Overriding the Package
+
+If you need to inject Nix packages or configure extra options via Nix, you can use the `.override` method to customize the package before installing it. 
+
+*Details on all available override parameters are in the [Configuration](configuration.md) section.*
+
+#### Local variable definition
+```nix
+{ inputs, pkgs, ... }:
+let
+  system = pkgs.stdenv.hostPlatform.system;
+  nvchad = inputs.nix4nvchad.packages.${system}.default.override {
+    # Custom configuration goes here
+  };
+in
+{
+  environment.systemPackages = [ nvchad ];
+  # Or for Home Manager: home.packages = [ nvchad ];
+}
+```
+
+### Using an Overlay (Recommended for Standalone)
+To make your customized NvChad globally accessible as `pkgs.nvchad`, you can define an overlay.
+
+```nix
+{ inputs, pkgs, ... }:
+let
+  system = pkgs.stdenv.hostPlatform.system;
+in
+{
+  nixpkgs.overlays = [
+    (final: prev: {
+      nvchad = inputs.nix4nvchad.packages.${system}.default.override {
+        # Custom configuration goes here
+      };
+    })
+  ];
+
+  # Now you can use it just like any other package from nixpkgs
+  environment.systemPackages = [ pkgs.nvchad ];
+}
+```

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,37 @@
+# Introduction
+
+![logo](https://nvchad.com/screenshots/onedark.webp)
+
+Welcome to the **nix4nvchad** documentation!
+
+**nix4nvchad** provides a seamless way to integrate [NvChad](https://nvchad.com/), a blazing fast Neovim configuration, into your Nix setup. 
+
+By leveraging Nix, you can declare your Neovim environment, language servers, and custom configurations deterministically, ensuring your editor setup is identical across all your machines.
+
+> [!NOTE]
+> This project is designed primarily for use with Nix Flakes. Make sure you have flakes enabled in your Nix installation. See [Flakes](https://wiki.nixos.org/wiki/Flakes) on the NixOS Wiki for more information.
+
+## How it works (Technical Details)
+
+Packaging NvChad for Nix isn't as straightforward as a standard application package. NvChad is fundamentally a *user configuration* for Neovim, not a standalone compiled binary. 
+
+By default, NvChad lazily loads plugins. On its first launch, it needs to write state files (like `lazy-lock.json`) and compiled modules to disk. In a standard Linux environment, it writes these to `~/.config/nvim` and `~/.local/share/nvim`.
+
+However, in Nix, all packages are built and stored in `/nix/store`, which is strictly **read-only**. If Neovim tries to run NvChad directly from the Nix store, the editor will crash or throw errors because it cannot write its required runtime files.
+
+**The Solution:**
+To bypass this limitation without breaking the deterministic nature of Nix, `nix4nvchad` uses a wrapper around the `nvim` executable. When you launch this wrapped `nvim`:
+1. It checks if the NvChad configuration already exists in your home directory (`~/.config/nvim`).
+2. If it does not exist, the wrapper automatically copies the immutable NvChad starter files and your custom Nix configurations from the `/nix/store` into your writable `~/.config/nvim` directory.
+3. Finally, it launches Neovim, allowing NvChad to write its lockfiles and state normally while still respecting the dependencies and LSP servers injected via Nix.
+
+## Features
+
+- **Home Manager Integration**: Easily configure NvChad using our provided Home Manager module.
+- **Standalone Package**: Use it independently of Home Manager by overriding the Nix derivation directly.
+- **Isolated Dependencies**: Manage your runtime dependencies (like LSP servers, formatters, and tools) in isolation. They are made available exclusively to NvChad without polluting your global system environment.
+
+> [!TIP]
+> If you are new to NvChad, we recommend reading through the [official NvChad documentation](https://nvchad.com/docs/quickstart/install) to familiarize yourself with its structure and defaults.
+
+Ready to get started? Head over to the [Installation](installation.md) guide.

--- a/docs/theme/catppuccin.css
+++ b/docs/theme/catppuccin.css
@@ -1,0 +1,868 @@
+/* https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html */
+.latte.hljs {
+  color: #4c4f69;
+  background: #eff1f5;
+}
+.latte .hljs-keyword {
+  color: #8839ef;
+}
+.latte .hljs-built_in {
+  color: #d20f39;
+}
+.latte .hljs-type {
+  color: #df8e1d;
+}
+.latte .hljs-literal {
+  color: #fe640b;
+}
+.latte .hljs-number {
+  color: #fe640b;
+}
+.latte .hljs-operator {
+  color: #04a5e5;
+}
+.latte .hljs-punctuation {
+  color: #5c5f77;
+}
+.latte .hljs-property {
+  color: #179299;
+}
+.latte .hljs-regexp {
+  color: #ea76cb;
+}
+.latte .hljs-string {
+  color: #40a02b;
+}
+.latte .hljs-char.escape_ {
+  color: #40a02b;
+}
+.latte .hljs-subst {
+  color: #6c6f85;
+}
+.latte .hljs-symbol {
+  color: #dd7878;
+}
+.latte .hljs-variable {
+  color: #8839ef;
+}
+.latte .hljs-variable.language_ {
+  color: #8839ef;
+}
+.latte .hljs-variable.constant_ {
+  color: #fe640b;
+}
+.latte .hljs-title {
+  color: #1e66f5;
+}
+.latte .hljs-title.class_ {
+  color: #df8e1d;
+}
+.latte .hljs-title.function_ {
+  color: #1e66f5;
+}
+.latte .hljs-params {
+  color: #4c4f69;
+}
+.latte .hljs-comment {
+  color: #7c7f93;
+}
+.latte .hljs-doctag {
+  color: #d20f39;
+}
+.latte .hljs-meta {
+  color: #fe640b;
+}
+.latte .hljs-section {
+  color: #1e66f5;
+}
+.latte .hljs-tag {
+  color: #179299;
+}
+.latte .hljs-name {
+  color: #8839ef;
+}
+.latte .hljs-attr {
+  color: #1e66f5;
+}
+.latte .hljs-attribute {
+  color: #40a02b;
+}
+.latte .hljs-bullet {
+  color: #179299;
+}
+.latte .hljs-code {
+  color: #40a02b;
+}
+.latte .hljs-emphasis {
+  color: #d20f39;
+  font-style: italic;
+}
+.latte .hljs-strong {
+  color: #d20f39;
+  font-weight: bold;
+}
+.latte .hljs-formula {
+  color: #179299;
+}
+.latte .hljs-link {
+  color: #209fb5;
+  font-style: italic;
+}
+.latte .hljs-quote {
+  color: #40a02b;
+  font-style: italic;
+}
+.latte .hljs-selector-tag {
+  color: #df8e1d;
+}
+.latte .hljs-selector-id {
+  color: #1e66f5;
+}
+.latte .hljs-selector-class {
+  color: #179299;
+}
+.latte .hljs-selector-attr {
+  color: #8839ef;
+}
+.latte .hljs-selector-pseudo {
+  color: #179299;
+}
+.latte .hljs-template-tag {
+  color: #dd7878;
+}
+.latte .hljs-template-variable {
+  color: #dd7878;
+}
+.latte .hljs-addition {
+  color: #40a02b;
+  background: rgba(64, 160, 43, 0.15);
+}
+.latte .hljs-deletion {
+  color: #d20f39;
+  background: rgba(210, 15, 57, 0.15);
+}
+.latte :is(h1, h2, h3, h4, h5, h6) a code {
+  color: #4c4f69;
+}
+.latte a code {
+  color: #1e66f5;
+}
+.latte code {
+  color: #4c4f69;
+  background: #e6e9ef;
+}
+.latte blockquote blockquote {
+  border-top: 0.1em solid #acb0be;
+  border-bottom: 0.1em solid #acb0be;
+}
+.latte hr {
+  border-color: #acb0be;
+  border-style: solid;
+}
+.latte del {
+  color: #7c7f93;
+}
+.latte .ace_gutter {
+  color: #8c8fa1;
+  background: #e6e9ef;
+}
+.latte .ace_gutter-active-line.ace_gutter-cell {
+  color: #ea76cb;
+  background: #e6e9ef;
+}
+.latte .tooltiptext {
+  background: #e6e9ef;
+  color: #4c4f69;
+}
+
+.frappe.hljs {
+  color: #c6d0f5;
+  background: #303446;
+}
+.frappe .hljs-keyword {
+  color: #ca9ee6;
+}
+.frappe .hljs-built_in {
+  color: #e78284;
+}
+.frappe .hljs-type {
+  color: #e5c890;
+}
+.frappe .hljs-literal {
+  color: #ef9f76;
+}
+.frappe .hljs-number {
+  color: #ef9f76;
+}
+.frappe .hljs-operator {
+  color: #99d1db;
+}
+.frappe .hljs-punctuation {
+  color: #b5bfe2;
+}
+.frappe .hljs-property {
+  color: #81c8be;
+}
+.frappe .hljs-regexp {
+  color: #f4b8e4;
+}
+.frappe .hljs-string {
+  color: #a6d189;
+}
+.frappe .hljs-char.escape_ {
+  color: #a6d189;
+}
+.frappe .hljs-subst {
+  color: #a5adce;
+}
+.frappe .hljs-symbol {
+  color: #eebebe;
+}
+.frappe .hljs-variable {
+  color: #ca9ee6;
+}
+.frappe .hljs-variable.language_ {
+  color: #ca9ee6;
+}
+.frappe .hljs-variable.constant_ {
+  color: #ef9f76;
+}
+.frappe .hljs-title {
+  color: #8caaee;
+}
+.frappe .hljs-title.class_ {
+  color: #e5c890;
+}
+.frappe .hljs-title.function_ {
+  color: #8caaee;
+}
+.frappe .hljs-params {
+  color: #c6d0f5;
+}
+.frappe .hljs-comment {
+  color: #949cbb;
+}
+.frappe .hljs-doctag {
+  color: #e78284;
+}
+.frappe .hljs-meta {
+  color: #ef9f76;
+}
+.frappe .hljs-section {
+  color: #8caaee;
+}
+.frappe .hljs-tag {
+  color: #81c8be;
+}
+.frappe .hljs-name {
+  color: #ca9ee6;
+}
+.frappe .hljs-attr {
+  color: #8caaee;
+}
+.frappe .hljs-attribute {
+  color: #a6d189;
+}
+.frappe .hljs-bullet {
+  color: #81c8be;
+}
+.frappe .hljs-code {
+  color: #a6d189;
+}
+.frappe .hljs-emphasis {
+  color: #e78284;
+  font-style: italic;
+}
+.frappe .hljs-strong {
+  color: #e78284;
+  font-weight: bold;
+}
+.frappe .hljs-formula {
+  color: #81c8be;
+}
+.frappe .hljs-link {
+  color: #85c1dc;
+  font-style: italic;
+}
+.frappe .hljs-quote {
+  color: #a6d189;
+  font-style: italic;
+}
+.frappe .hljs-selector-tag {
+  color: #e5c890;
+}
+.frappe .hljs-selector-id {
+  color: #8caaee;
+}
+.frappe .hljs-selector-class {
+  color: #81c8be;
+}
+.frappe .hljs-selector-attr {
+  color: #ca9ee6;
+}
+.frappe .hljs-selector-pseudo {
+  color: #81c8be;
+}
+.frappe .hljs-template-tag {
+  color: #eebebe;
+}
+.frappe .hljs-template-variable {
+  color: #eebebe;
+}
+.frappe .hljs-addition {
+  color: #a6d189;
+  background: rgba(166, 209, 137, 0.15);
+}
+.frappe .hljs-deletion {
+  color: #e78284;
+  background: rgba(231, 130, 132, 0.15);
+}
+.frappe :is(h1, h2, h3, h4, h5, h6) a code {
+  color: #c6d0f5;
+}
+.frappe a code {
+  color: #8caaee;
+}
+.frappe code {
+  color: #c6d0f5;
+  background: #292c3c;
+}
+.frappe blockquote blockquote {
+  border-top: 0.1em solid #626880;
+  border-bottom: 0.1em solid #626880;
+}
+.frappe hr {
+  border-color: #626880;
+  border-style: solid;
+}
+.frappe del {
+  color: #949cbb;
+}
+.frappe .ace_gutter {
+  color: #838ba7;
+  background: #292c3c;
+}
+.frappe .ace_gutter-active-line.ace_gutter-cell {
+  color: #f4b8e4;
+  background: #292c3c;
+}
+.frappe .tooltiptext {
+  background: #292c3c;
+  color: #c6d0f5;
+}
+
+.macchiato.hljs {
+  color: #cad3f5;
+  background: #24273a;
+}
+.macchiato .hljs-keyword {
+  color: #c6a0f6;
+}
+.macchiato .hljs-built_in {
+  color: #ed8796;
+}
+.macchiato .hljs-type {
+  color: #eed49f;
+}
+.macchiato .hljs-literal {
+  color: #f5a97f;
+}
+.macchiato .hljs-number {
+  color: #f5a97f;
+}
+.macchiato .hljs-operator {
+  color: #91d7e3;
+}
+.macchiato .hljs-punctuation {
+  color: #b8c0e0;
+}
+.macchiato .hljs-property {
+  color: #8bd5ca;
+}
+.macchiato .hljs-regexp {
+  color: #f5bde6;
+}
+.macchiato .hljs-string {
+  color: #a6da95;
+}
+.macchiato .hljs-char.escape_ {
+  color: #a6da95;
+}
+.macchiato .hljs-subst {
+  color: #a5adcb;
+}
+.macchiato .hljs-symbol {
+  color: #f0c6c6;
+}
+.macchiato .hljs-variable {
+  color: #c6a0f6;
+}
+.macchiato .hljs-variable.language_ {
+  color: #c6a0f6;
+}
+.macchiato .hljs-variable.constant_ {
+  color: #f5a97f;
+}
+.macchiato .hljs-title {
+  color: #8aadf4;
+}
+.macchiato .hljs-title.class_ {
+  color: #eed49f;
+}
+.macchiato .hljs-title.function_ {
+  color: #8aadf4;
+}
+.macchiato .hljs-params {
+  color: #cad3f5;
+}
+.macchiato .hljs-comment {
+  color: #939ab7;
+}
+.macchiato .hljs-doctag {
+  color: #ed8796;
+}
+.macchiato .hljs-meta {
+  color: #f5a97f;
+}
+.macchiato .hljs-section {
+  color: #8aadf4;
+}
+.macchiato .hljs-tag {
+  color: #8bd5ca;
+}
+.macchiato .hljs-name {
+  color: #c6a0f6;
+}
+.macchiato .hljs-attr {
+  color: #8aadf4;
+}
+.macchiato .hljs-attribute {
+  color: #a6da95;
+}
+.macchiato .hljs-bullet {
+  color: #8bd5ca;
+}
+.macchiato .hljs-code {
+  color: #a6da95;
+}
+.macchiato .hljs-emphasis {
+  color: #ed8796;
+  font-style: italic;
+}
+.macchiato .hljs-strong {
+  color: #ed8796;
+  font-weight: bold;
+}
+.macchiato .hljs-formula {
+  color: #8bd5ca;
+}
+.macchiato .hljs-link {
+  color: #7dc4e4;
+  font-style: italic;
+}
+.macchiato .hljs-quote {
+  color: #a6da95;
+  font-style: italic;
+}
+.macchiato .hljs-selector-tag {
+  color: #eed49f;
+}
+.macchiato .hljs-selector-id {
+  color: #8aadf4;
+}
+.macchiato .hljs-selector-class {
+  color: #8bd5ca;
+}
+.macchiato .hljs-selector-attr {
+  color: #c6a0f6;
+}
+.macchiato .hljs-selector-pseudo {
+  color: #8bd5ca;
+}
+.macchiato .hljs-template-tag {
+  color: #f0c6c6;
+}
+.macchiato .hljs-template-variable {
+  color: #f0c6c6;
+}
+.macchiato .hljs-addition {
+  color: #a6da95;
+  background: rgba(166, 218, 149, 0.15);
+}
+.macchiato .hljs-deletion {
+  color: #ed8796;
+  background: rgba(237, 135, 150, 0.15);
+}
+.macchiato :is(h1, h2, h3, h4, h5, h6) a code {
+  color: #cad3f5;
+}
+.macchiato a code {
+  color: #8aadf4;
+}
+.macchiato code {
+  color: #cad3f5;
+  background: #1e2030;
+}
+.macchiato blockquote blockquote {
+  border-top: 0.1em solid #5b6078;
+  border-bottom: 0.1em solid #5b6078;
+}
+.macchiato hr {
+  border-color: #5b6078;
+  border-style: solid;
+}
+.macchiato del {
+  color: #939ab7;
+}
+.macchiato .ace_gutter {
+  color: #8087a2;
+  background: #1e2030;
+}
+.macchiato .ace_gutter-active-line.ace_gutter-cell {
+  color: #f5bde6;
+  background: #1e2030;
+}
+.macchiato .tooltiptext {
+  background: #1e2030;
+  color: #cad3f5;
+}
+
+.mocha.hljs {
+  color: #cdd6f4;
+  background: #1e1e2e;
+}
+.mocha .hljs-keyword {
+  color: #cba6f7;
+}
+.mocha .hljs-built_in {
+  color: #f38ba8;
+}
+.mocha .hljs-type {
+  color: #f9e2af;
+}
+.mocha .hljs-literal {
+  color: #fab387;
+}
+.mocha .hljs-number {
+  color: #fab387;
+}
+.mocha .hljs-operator {
+  color: #89dceb;
+}
+.mocha .hljs-punctuation {
+  color: #bac2de;
+}
+.mocha .hljs-property {
+  color: #94e2d5;
+}
+.mocha .hljs-regexp {
+  color: #f5c2e7;
+}
+.mocha .hljs-string {
+  color: #a6e3a1;
+}
+.mocha .hljs-char.escape_ {
+  color: #a6e3a1;
+}
+.mocha .hljs-subst {
+  color: #a6adc8;
+}
+.mocha .hljs-symbol {
+  color: #f2cdcd;
+}
+.mocha .hljs-variable {
+  color: #cba6f7;
+}
+.mocha .hljs-variable.language_ {
+  color: #cba6f7;
+}
+.mocha .hljs-variable.constant_ {
+  color: #fab387;
+}
+.mocha .hljs-title {
+  color: #89b4fa;
+}
+.mocha .hljs-title.class_ {
+  color: #f9e2af;
+}
+.mocha .hljs-title.function_ {
+  color: #89b4fa;
+}
+.mocha .hljs-params {
+  color: #cdd6f4;
+}
+.mocha .hljs-comment {
+  color: #9399b2;
+}
+.mocha .hljs-doctag {
+  color: #f38ba8;
+}
+.mocha .hljs-meta {
+  color: #fab387;
+}
+.mocha .hljs-section {
+  color: #89b4fa;
+}
+.mocha .hljs-tag {
+  color: #94e2d5;
+}
+.mocha .hljs-name {
+  color: #cba6f7;
+}
+.mocha .hljs-attr {
+  color: #89b4fa;
+}
+.mocha .hljs-attribute {
+  color: #a6e3a1;
+}
+.mocha .hljs-bullet {
+  color: #94e2d5;
+}
+.mocha .hljs-code {
+  color: #a6e3a1;
+}
+.mocha .hljs-emphasis {
+  color: #f38ba8;
+  font-style: italic;
+}
+.mocha .hljs-strong {
+  color: #f38ba8;
+  font-weight: bold;
+}
+.mocha .hljs-formula {
+  color: #94e2d5;
+}
+.mocha .hljs-link {
+  color: #74c7ec;
+  font-style: italic;
+}
+.mocha .hljs-quote {
+  color: #a6e3a1;
+  font-style: italic;
+}
+.mocha .hljs-selector-tag {
+  color: #f9e2af;
+}
+.mocha .hljs-selector-id {
+  color: #89b4fa;
+}
+.mocha .hljs-selector-class {
+  color: #94e2d5;
+}
+.mocha .hljs-selector-attr {
+  color: #cba6f7;
+}
+.mocha .hljs-selector-pseudo {
+  color: #94e2d5;
+}
+.mocha .hljs-template-tag {
+  color: #f2cdcd;
+}
+.mocha .hljs-template-variable {
+  color: #f2cdcd;
+}
+.mocha .hljs-addition {
+  color: #a6e3a1;
+  background: rgba(166, 227, 161, 0.15);
+}
+.mocha .hljs-deletion {
+  color: #f38ba8;
+  background: rgba(243, 139, 168, 0.15);
+}
+.mocha :is(h1, h2, h3, h4, h5, h6) a code {
+  color: #cdd6f4;
+}
+.mocha a code {
+  color: #89b4fa;
+}
+.mocha code {
+  color: #cdd6f4;
+  background: #181825;
+}
+.mocha blockquote blockquote {
+  border-top: 0.1em solid #585b70;
+  border-bottom: 0.1em solid #585b70;
+}
+.mocha hr {
+  border-color: #585b70;
+  border-style: solid;
+}
+.mocha del {
+  color: #9399b2;
+}
+.mocha .ace_gutter {
+  color: #7f849c;
+  background: #181825;
+}
+.mocha .ace_gutter-active-line.ace_gutter-cell {
+  color: #f5c2e7;
+  background: #181825;
+}
+.mocha .tooltiptext {
+  background: #181825;
+  color: #cdd6f4;
+}
+
+.latte {
+  --bg: #eff1f5;
+  --fg: #4c4f69;
+  --sidebar-bg: #e6e9ef;
+  --sidebar-fg: #4c4f69;
+  --sidebar-non-existant: #9ca0b0;
+  --sidebar-active: #1e66f5;
+  --sidebar-spacer: #9ca0b0;
+  --scrollbar: #9ca0b0;
+  --icons: #9ca0b0;
+  --icons-hover: #7c7f93;
+  --links: #1e66f5;
+  --inline-code-color: #4c4f69;
+  --theme-popup-bg: #e6e9ef;
+  --theme-popup-border: #9ca0b0;
+  --theme-hover: #ccd0da;
+  --quote-bg: #e6e9ef;
+  --quote-border: #dce0e8;
+  --table-border-color: #ccd0da;
+  --table-header-bg: #e6e9ef;
+  --table-alternate-bg: #e6e9ef;
+  --searchbar-border-color: #ccd0da;
+  --searchbar-bg: #e6e9ef;
+  --searchbar-fg: #4c4f69;
+  --searchbar-shadow-color: #dce0e8;
+  --searchresults-header-fg: #4c4f69;
+  --searchresults-border-color: #ccd0da;
+  --searchresults-li-bg: #eff1f5;
+  --sidebar-header-border-color: #7287fd;
+  --search-mark-bg: #fe640b;
+  --warning-border: #fe640b;
+  --color-scheme: light;
+  --copy-button-filter: brightness(0) saturate(100%) invert(47%) sepia(6%) saturate(1263%) hue-rotate(195deg) brightness(90%) contrast(81%);
+  --copy-button-filter-hover: brightness(0) saturate(100%) invert(30%) sepia(80%) saturate(1850%) hue-rotate(209deg) brightness(94%) contrast(105%);
+  --blockquote-note-color: #1e66f5;
+  --blockquote-tip-color: #40a02b;
+  --blockquote-important-color: #8839ef;
+  --blockquote-warning-color: #df8e1d;
+  --blockquote-caution-color: #d20f39;
+}
+
+.frappe {
+  --bg: #303446;
+  --fg: #c6d0f5;
+  --sidebar-bg: #292c3c;
+  --sidebar-fg: #c6d0f5;
+  --sidebar-non-existant: #737994;
+  --sidebar-active: #8caaee;
+  --sidebar-spacer: #737994;
+  --scrollbar: #737994;
+  --icons: #737994;
+  --icons-hover: #949cbb;
+  --links: #8caaee;
+  --inline-code-color: #c6d0f5;
+  --theme-popup-bg: #292c3c;
+  --theme-popup-border: #737994;
+  --theme-hover: #414559;
+  --quote-bg: #292c3c;
+  --quote-border: #232634;
+  --table-border-color: #414559;
+  --table-header-bg: #292c3c;
+  --table-alternate-bg: #292c3c;
+  --searchbar-border-color: #414559;
+  --searchbar-bg: #292c3c;
+  --searchbar-fg: #c6d0f5;
+  --searchbar-shadow-color: #232634;
+  --searchresults-header-fg: #c6d0f5;
+  --searchresults-border-color: #414559;
+  --searchresults-li-bg: #303446;
+  --sidebar-header-border-color: #babbf1;
+  --search-mark-bg: #ef9f76;
+  --warning-border: #ef9f76;
+  --color-scheme: dark;
+  --copy-button-filter: brightness(0) saturate(100%) invert(82%) sepia(6%) saturate(1287%) hue-rotate(192deg) brightness(86%) contrast(85%);
+  --copy-button-filter-hover: brightness(0) saturate(100%) invert(68%) sepia(16%) saturate(1070%) hue-rotate(185deg) brightness(96%) contrast(95%);
+  --blockquote-note-color: #8caaee;
+  --blockquote-tip-color: #a6d189;
+  --blockquote-important-color: #ca9ee6;
+  --blockquote-warning-color: #e5c890;
+  --blockquote-caution-color: #e78284;
+}
+
+.macchiato {
+  --bg: #24273a;
+  --fg: #cad3f5;
+  --sidebar-bg: #1e2030;
+  --sidebar-fg: #cad3f5;
+  --sidebar-non-existant: #6e738d;
+  --sidebar-active: #8aadf4;
+  --sidebar-spacer: #6e738d;
+  --scrollbar: #6e738d;
+  --icons: #6e738d;
+  --icons-hover: #939ab7;
+  --links: #8aadf4;
+  --inline-code-color: #cad3f5;
+  --theme-popup-bg: #1e2030;
+  --theme-popup-border: #6e738d;
+  --theme-hover: #363a4f;
+  --quote-bg: #1e2030;
+  --quote-border: #181926;
+  --table-border-color: #363a4f;
+  --table-header-bg: #1e2030;
+  --table-alternate-bg: #1e2030;
+  --searchbar-border-color: #363a4f;
+  --searchbar-bg: #1e2030;
+  --searchbar-fg: #cad3f5;
+  --searchbar-shadow-color: #181926;
+  --searchresults-header-fg: #cad3f5;
+  --searchresults-border-color: #363a4f;
+  --searchresults-li-bg: #24273a;
+  --sidebar-header-border-color: #b7bdf8;
+  --search-mark-bg: #f5a97f;
+  --warning-border: #f5a97f;
+  --color-scheme: dark;
+  --copy-button-filter: brightness(0) saturate(100%) invert(75%) sepia(18%) saturate(361%) hue-rotate(190deg) brightness(91%) contrast(86%);
+  --copy-button-filter-hover: brightness(0) saturate(100%) invert(67%) sepia(17%) saturate(1007%) hue-rotate(183deg) brightness(99%) contrast(94%);
+  --blockquote-note-color: #8aadf4;
+  --blockquote-tip-color: #a6da95;
+  --blockquote-important-color: #c6a0f6;
+  --blockquote-warning-color: #eed49f;
+  --blockquote-caution-color: #ed8796;
+}
+
+.mocha {
+  --bg: #1e1e2e;
+  --fg: #cdd6f4;
+  --sidebar-bg: #181825;
+  --sidebar-fg: #cdd6f4;
+  --sidebar-non-existant: #6c7086;
+  --sidebar-active: #89b4fa;
+  --sidebar-spacer: #6c7086;
+  --scrollbar: #6c7086;
+  --icons: #6c7086;
+  --icons-hover: #9399b2;
+  --links: #89b4fa;
+  --inline-code-color: #cdd6f4;
+  --theme-popup-bg: #181825;
+  --theme-popup-border: #6c7086;
+  --theme-hover: #313244;
+  --quote-bg: #181825;
+  --quote-border: #11111b;
+  --table-border-color: #313244;
+  --table-header-bg: #181825;
+  --table-alternate-bg: #181825;
+  --searchbar-border-color: #313244;
+  --searchbar-bg: #181825;
+  --searchbar-fg: #cdd6f4;
+  --searchbar-shadow-color: #11111b;
+  --searchresults-header-fg: #cdd6f4;
+  --searchresults-border-color: #313244;
+  --searchresults-li-bg: #1e1e2e;
+  --sidebar-header-border-color: #b4befe;
+  --search-mark-bg: #fab387;
+  --warning-border: #fab387;
+  --color-scheme: dark;
+  --copy-button-filter: brightness(0) saturate(100%) invert(84%) sepia(9%) saturate(767%) hue-rotate(192deg) brightness(84%) contrast(84%);
+  --copy-button-filter-hover: brightness(0) saturate(100%) invert(68%) sepia(18%) saturate(951%) hue-rotate(180deg) brightness(98%) contrast(100%);
+  --blockquote-note-color: #89b4fa;
+  --blockquote-tip-color: #a6e3a1;
+  --blockquote-important-color: #cba6f7;
+  --blockquote-warning-color: #f9e2af;
+  --blockquote-caution-color: #f38ba8;
+}

--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -1,0 +1,365 @@
+<!DOCTYPE HTML>
+<html lang="{{ language }}" class="{{ default_theme }} sidebar-visible" dir="{{ text_direction }}">
+    <head>
+        <!-- Book generated using mdBook -->
+        <meta charset="UTF-8">
+        <title>{{ title }}</title>
+        {{#if is_print }}
+        <meta name="robots" content="noindex">
+        {{/if}}
+        {{#if base_url}}
+        <base href="{{ base_url }}">
+        {{/if}}
+
+
+        <!-- Custom HTML head -->
+        {{> head}}
+
+        <meta name="description" content="{{ description }}">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="theme-color" content="#ffffff">
+
+        {{#if favicon_svg}}
+        <link rel="icon" href="{{ resource "favicon.svg" }}">
+        {{/if}}
+        {{#if favicon_png}}
+        <link rel="shortcut icon" href="{{ resource "favicon.png" }}">
+        {{/if}}
+        <link rel="stylesheet" href="{{ resource "css/variables.css" }}">
+        <link rel="stylesheet" href="{{ resource "css/general.css" }}">
+        <link rel="stylesheet" href="{{ resource "css/chrome.css" }}">
+        {{#if print_enable}}
+        <link rel="stylesheet" href="{{ resource "css/print.css" }}" media="print">
+        {{/if}}
+
+        <!-- Fonts -->
+        <link rel="stylesheet" href="{{ resource "fonts/fonts.css" }}">
+
+        <!-- Highlight.js Stylesheets -->
+        <link rel="stylesheet" id="mdbook-highlight-css" href="{{ resource "highlight.css" }}">
+        <link rel="stylesheet" id="mdbook-tomorrow-night-css" href="{{ resource "tomorrow-night.css" }}">
+        <link rel="stylesheet" id="mdbook-ayu-highlight-css" href="{{ resource "ayu-highlight.css" }}">
+
+        <!-- Custom theme stylesheets -->
+        {{#each additional_css}}
+        <link rel="stylesheet" href="{{ resource this }}">
+        {{/each}}
+
+        {{#if mathjax_support}}
+        <!-- MathJax -->
+        <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        {{/if}}
+
+        <!-- Provide site root and default themes to javascript -->
+        <script>
+            const path_to_root = "{{ path_to_root }}";
+            const default_light_theme = "{{ default_theme }}";
+            const default_dark_theme = "{{ preferred_dark_theme }}";
+        {{#if search_js}}
+            window.path_to_searchindex_js = "{{ resource "searchindex.js" }}";
+        {{/if}}
+        </script>
+        <!-- Start loading toc.js asap -->
+        <script src="{{ resource "toc.js" }}"></script>
+    </head>
+    <body>
+    <div id="mdbook-help-container">
+        <div id="mdbook-help-popup">
+            <h2 class="mdbook-help-title">Keyboard shortcuts</h2>
+            <div>
+                <p>Press <kbd>←</kbd> or <kbd>→</kbd> to navigate between chapters</p>
+                {{#if search_enabled}}
+                <p>Press <kbd>S</kbd> or <kbd>/</kbd> to search in the book</p>
+                {{/if}}
+                <p>Press <kbd>?</kbd> to show this help</p>
+                <p>Press <kbd>Esc</kbd> to hide this help</p>
+            </div>
+        </div>
+    </div>
+    <div id="mdbook-body-container">
+        <!-- Work around some values being stored in localStorage wrapped in quotes -->
+        <script>
+            try {
+                let theme = localStorage.getItem('mdbook-theme');
+                let sidebar = localStorage.getItem('mdbook-sidebar');
+
+                if (theme.startsWith('"') && theme.endsWith('"')) {
+                    localStorage.setItem('mdbook-theme', theme.slice(1, theme.length - 1));
+                }
+
+                if (sidebar.startsWith('"') && sidebar.endsWith('"')) {
+                    localStorage.setItem('mdbook-sidebar', sidebar.slice(1, sidebar.length - 1));
+                }
+            } catch (e) { }
+        </script>
+
+        <!-- Set the theme before any content is loaded, prevents flash -->
+        <script>
+            const default_theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? default_dark_theme : default_light_theme;
+            let theme;
+            try { theme = localStorage.getItem('mdbook-theme'); } catch(e) { }
+            if (theme === null || theme === undefined) { theme = default_theme; }
+            const html = document.documentElement;
+            html.classList.remove('{{ default_theme }}')
+            html.classList.add(theme);
+            html.classList.add("js");
+        </script>
+
+        <input type="checkbox" id="mdbook-sidebar-toggle-anchor" class="hidden">
+
+        <!-- Hide / unhide sidebar before it is displayed -->
+        <script>
+            let sidebar = null;
+            const sidebar_toggle = document.getElementById("mdbook-sidebar-toggle-anchor");
+            if (document.body.clientWidth >= 1080) {
+                try { sidebar = localStorage.getItem('mdbook-sidebar'); } catch(e) { }
+                sidebar = sidebar || 'visible';
+            } else {
+                sidebar = 'hidden';
+                sidebar_toggle.checked = false;
+            }
+            if (sidebar === 'visible') {
+                sidebar_toggle.checked = true;
+            } else {
+                html.classList.remove('sidebar-visible');
+            }
+        </script>
+
+        <nav id="mdbook-sidebar" class="sidebar" aria-label="Table of contents">
+            <!-- populated by js -->
+            <mdbook-sidebar-scrollbox class="sidebar-scrollbox"></mdbook-sidebar-scrollbox>
+            <noscript>
+                <iframe class="sidebar-iframe-outer" src="{{ path_to_root }}toc.html"></iframe>
+            </noscript>
+            <div id="mdbook-sidebar-resize-handle" class="sidebar-resize-handle">
+                <div class="sidebar-resize-indicator"></div>
+            </div>
+        </nav>
+
+        <div id="mdbook-page-wrapper" class="page-wrapper">
+
+            <div class="page">
+                {{> header}}
+                <div id="mdbook-menu-bar-hover-placeholder"></div>
+                <div id="mdbook-menu-bar" class="menu-bar sticky">
+                    <div class="left-buttons">
+                        <label id="mdbook-sidebar-toggle" class="icon-button" for="mdbook-sidebar-toggle-anchor" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="mdbook-sidebar">
+                            {{fa "solid" "bars"}}
+                        </label>
+                        <button id="mdbook-theme-toggle" class="icon-button" type="button" title="Change theme" aria-label="Change theme" aria-haspopup="true" aria-expanded="false" aria-controls="mdbook-theme-list">
+                            {{fa "solid" "paintbrush"}}
+                        </button>
+                        <ul id="mdbook-theme-list" class="theme-popup" aria-label="Themes" role="menu">
+                            <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-latte">Latte</button></li>
+                            <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-frappe">Frappé</button></li>
+                            <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-macchiato">Macchiato</button></li>
+                            <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-mocha">Mocha</button></li>
+                        </ul>
+                        {{#if search_enabled}}
+                        <button id="mdbook-search-toggle" class="icon-button" type="button" title="Search (`/`)" aria-label="Toggle Searchbar" aria-expanded="false" aria-keyshortcuts="/ s" aria-controls="mdbook-searchbar">
+                            {{fa "solid" "magnifying-glass"}}
+                        </button>
+                        {{/if}}
+                    </div>
+
+                    <h1 class="menu-title">{{ book_title }}</h1>
+
+                    <div class="right-buttons">
+                        {{#if print_enable}}
+                        <a href="{{ path_to_root }}print.html" title="Print this book" aria-label="Print this book">
+                            {{fa "solid" "print" "print-button"}}
+                        </a>
+                        {{/if}}
+                        {{#if git_repository_url}}
+                        <a href="{{git_repository_url}}" title="Git repository" aria-label="Git repository">
+                            {{fa git_repository_icon_class git_repository_icon}}
+                        </a>
+                        {{/if}}
+                        {{#if git_repository_edit_url}}
+                        <a href="{{git_repository_edit_url}}" title="Suggest an edit" aria-label="Suggest an edit" rel="edit">
+                            {{fa "solid" "pencil" "git-edit-button"}}
+                        </a>
+                        {{/if}}
+
+                    </div>
+                </div>
+
+                {{#if search_enabled}}
+                <div id="mdbook-search-wrapper" class="hidden">
+                    <form id="mdbook-searchbar-outer" class="searchbar-outer">
+                        <div class="search-wrapper">
+                            <input type="search" id="mdbook-searchbar" name="searchbar" placeholder="Search this book ..." aria-controls="mdbook-searchresults-outer" aria-describedby="searchresults-header">
+                            <div class="spinner-wrapper">
+                                {{fa "solid" "spinner" "fa-spin"}}
+                            </div>
+                        </div>
+                    </form>
+                    <div id="mdbook-searchresults-outer" class="searchresults-outer hidden">
+                        <div id="mdbook-searchresults-header" class="searchresults-header"></div>
+                        <ul id="mdbook-searchresults">
+                        </ul>
+                    </div>
+                </div>
+                {{/if}}
+
+                <!-- Apply ARIA attributes after the sidebar and the sidebar toggle button are added to the DOM -->
+                <script>
+                    document.getElementById('mdbook-sidebar-toggle').setAttribute('aria-expanded', sidebar === 'visible');
+                    document.getElementById('mdbook-sidebar').setAttribute('aria-hidden', sidebar !== 'visible');
+                    Array.from(document.querySelectorAll('#mdbook-sidebar a')).forEach(function(link) {
+                        link.setAttribute('tabIndex', sidebar === 'visible' ? 0 : -1);
+                    });
+                </script>
+
+                <div id="mdbook-content" class="content">
+                    <main>
+                        {{{ content }}}
+                    </main>
+
+                    <nav class="nav-wrapper" aria-label="Page navigation">
+                        <!-- Mobile navigation buttons -->
+                        {{#if previous}}
+                            <a rel="prev" href="{{ path_to_root }}{{previous.link}}" class="mobile-nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
+                                {{#if (eq ../text_direction "rtl")}}
+                                {{fa "solid" "angle-right"}}
+                                {{else}}
+                                {{fa "solid" "angle-left"}}
+                                {{/if}}
+                            </a>
+                        {{/if}}
+
+                        {{#if next}}
+                            <a rel="next prefetch" href="{{ path_to_root }}{{next.link}}" class="mobile-nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
+                                {{#if (eq ../text_direction "rtl")}}
+                                {{fa "solid" "angle-left"}}
+                                {{else}}
+                                {{fa "solid" "angle-right"}}
+                                {{/if}}
+                            </a>
+                        {{/if}}
+
+                        <div style="clear: both"></div>
+                    </nav>
+                </div>
+            </div>
+
+            <nav class="nav-wide-wrapper" aria-label="Page navigation">
+                {{#if previous}}
+                    <a rel="prev" href="{{ path_to_root }}{{previous.link}}" class="nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
+                        {{#if (eq ../text_direction "rtl")}}
+                        {{fa "solid" "angle-right"}}
+                        {{else}}
+                        {{fa "solid" "angle-left"}}
+                        {{/if}}
+                    </a>
+                {{/if}}
+
+                {{#if next}}
+                    <a rel="next prefetch" href="{{ path_to_root }}{{next.link}}" class="nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
+                        {{#if (eq text_direction "rtl")}}
+                        {{fa "solid" "angle-left"}}
+                        {{else}}
+                        {{fa "solid" "angle-right"}}
+                        {{/if}}
+                    </a>
+                {{/if}}
+            </nav>
+
+        </div>
+
+        <template id=fa-eye>{{fa "solid" "eye"}}</template>
+        <template id=fa-eye-slash>{{fa "solid" "eye-slash"}}</template>
+        <template id=fa-copy>{{fa "regular" "copy"}}</template>
+        <template id=fa-play>{{fa "solid" "play"}}</template>
+        <template id=fa-clock-rotate-left>{{fa "solid" "clock-rotate-left"}}</template>
+
+        {{#if live_reload_endpoint}}
+        <!-- Livereload script (if served using the cli tool) -->
+        <script>
+            const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+            const wsAddress = wsProtocol + "//" + location.host + "/" + "{{{live_reload_endpoint}}}";
+            const socket = new WebSocket(wsAddress);
+            socket.onmessage = function (event) {
+                if (event.data === "reload") {
+                    socket.close();
+                    location.reload();
+                }
+            };
+
+            window.onbeforeunload = function() {
+                socket.close();
+            }
+        </script>
+        {{/if}}
+
+        {{#if playground_line_numbers}}
+        <script>
+            window.playground_line_numbers = true;
+        </script>
+        {{/if}}
+
+        {{#if playground_copyable}}
+        <script>
+            window.playground_copyable = true;
+        </script>
+        {{/if}}
+
+        {{#if playground_js}}
+        <script src="{{ resource "ace.js" }}"></script>
+        <script src="{{ resource "mode-rust.js" }}"></script>
+        <script src="{{ resource "editor.js" }}"></script>
+        <script src="{{ resource "theme-dawn.js" }}"></script>
+        <script src="{{ resource "theme-tomorrow_night.js" }}"></script>
+        {{/if}}
+
+        {{#if search_js}}
+        <script src="{{ resource "elasticlunr.min.js" }}"></script>
+        <script src="{{ resource "mark.min.js" }}"></script>
+        <script src="{{ resource "searcher.js" }}"></script>
+        {{/if}}
+
+        <script src="{{ resource "clipboard.min.js" }}"></script>
+        <script src="{{ resource "highlight.js" }}"></script>
+        <script src="{{ resource "book.js" }}"></script>
+
+        <!-- Custom JS scripts -->
+        {{#each additional_js}}
+        <script src="{{ resource this}}"></script>
+        {{/each}}
+
+        {{#if is_print}}
+        {{#if mathjax_support}}
+        <script>
+        window.addEventListener('load', function() {
+            MathJax.Hub.Register.StartupHook('End', function() {
+                window.setTimeout(window.print, 100);
+            });
+        });
+        </script>
+        {{else}}
+        <script>
+        window.addEventListener('load', function() {
+            window.setTimeout(window.print, 100);
+        });
+        </script>
+        {{/if}}
+        {{/if}}
+
+        {{#if fragment_map}}
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                const fragmentMap =
+                    {{{fragment_map}}}
+                ;
+                const target = fragmentMap[window.location.hash];
+                if (target) {
+                    let url = new URL(target, window.location.href);
+                    window.location.replace(url.href);
+                }
+            });
+        </script>
+        {{/if}}
+
+    </div>
+    </body>
+</html>

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
         };
         apps = rec {
           nvchad =
-            flake-utils.lib.mkApp { 
+            flake-utils.lib.mkApp {
               drv = self.packages.${system}.nvchad;
               name = "nvim";
             }
@@ -54,6 +54,9 @@
           default = nvchad;
         };
         checks = self.packages.${system};
+        devShells.default = pkgs.mkShell {
+          buildInputs = [ pkgs.mdbook ];
+        };
       }
     )
     // {
@@ -61,6 +64,8 @@
         nvchad = import ./nix/module.nix { starterRepo = nvchad-starter; };
         default = nvchad;
       };
+      # DEPRECATED: This attribute will be removed soon.
+      # Use homeManagerModules.default instead.
       homeManagerModule = self.homeManagerModules.nvchad;
     };
 }


### PR DESCRIPTION
- Initialize mdBook structure in `docs/` and add Catppuccin theme.
- Create comprehensive documentation covering introduction, installation, configuration, and advanced usage.
- Add `.github/workflows/docs.yml` to automatically deploy mdBook to GitHub Pages.
- Add `mdbook` to `devShells` in `flake.nix` for local development.
- Rewrite `README.md` to be concise, visually appealing with badges, and point users to the new mdBook documentation.
- Mark `homeManagerModule` in `flake.nix` as deprecated and advise users to use `homeManagerModules.default` instead. Add a dedicated `deprecated.md` page in the documentation explaining this.