### PR TITLE
fix(flake): drop unsupported x86_64-darwin outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,70 @@ nix run github:nix-community/nix4nvchad
 > [!WARNING]  
 > If you already have an existing Neovim configuration at `~/.config/nvim`, this command will create a backup before launching. Make sure your environment is safe.
 
+## Intel macOS
+
+`x86_64-darwin` is not included in the officially tested flake outputs
+because current Nixpkgs releases no longer support Intel macOS. Commands
+such as the following are therefore unsupported on Intel Macs:
+
+```console
+nix run github:nix-community/nix4nvchad
+```
+
+As a best-effort workaround, the Home Manager module can still be used
+with the last Nixpkgs branch that supports Intel macOS:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
+
+    home-manager = {
+      url = "github:nix-community/home-manager/release-26.05";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nix4nvchad = {
+      url = "github:nix-community/nix4nvchad";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      home-manager,
+      nix4nvchad,
+      ...
+    }:
+    let
+      system = "x86_64-darwin";
+
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+    in
+    {
+      homeConfigurations.example = home-manager.lib.homeManagerConfiguration {
+        inherit pkgs;
+
+        modules = [
+          nix4nvchad.homeManagerModules.default
+
+          {
+            programs.nvchad.enable = true;
+          }
+        ];
+      };
+    };
+}
+```
+
+This works because the module builds the package with the user's `pkgs`.
+It does not add `packages.x86_64-darwin` or `apps.x86_64-darwin` to
+nix4nvchad itself. This workaround is best effort and is not tested by
+the project's CI.
+
 ## Usage Guide
 
 Comprehensive guides on installation, configuration, and advanced usage are available in the official **[Documentation](https://nix-community.github.io/nix4nvchad/)**.

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1782948114,
@@ -53,24 +35,8 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nvchad-starter": "nvchad-starter"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -16,10 +16,8 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
-    flake-utils.url = "github:numtide/flake-utils";
-
     nvchad-starter = {
-      url = "github:NvChad/starter/main"; # people who want to use a different starter could override this.
+      url = "github:NvChad/starter/main";
       flake = false;
     };
   };
@@ -28,42 +26,71 @@
     {
       self,
       nixpkgs,
-      flake-utils,
       nvchad-starter,
     }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-      in
-      {
-        packages = rec {
-          nvchad = pkgs.callPackage ./nix/nvchad.nix { starterRepo = nvchad-starter; };
-          default = nvchad;
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      pkgsFor = forAllSystems (
+        system:
+        import nixpkgs {
+          inherit system;
+        }
+      );
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          nvchadPackage = pkgsFor.${system}.callPackage ./nix/nvchad.nix {
+            starterRepo = nvchad-starter;
+          };
+        in
+        {
+          nvchad = nvchadPackage;
+          default = nvchadPackage;
+        }
+      );
+
+      apps = forAllSystems (
+        system:
+        let
+          package = self.packages.${system}.nvchad;
+          nvchadApp = {
+            type = "app";
+            program = "${package}/bin/nvim";
+            meta = package.meta;
+          };
+        in
+        {
+          nvchad = nvchadApp;
+          default = nvchadApp;
+        }
+      );
+
+      checks = self.packages;
+
+      devShells = forAllSystems (system: {
+        default = pkgsFor.${system}.mkShell {
+          buildInputs = [ pkgsFor.${system}.mdbook ];
         };
-        apps = rec {
-          nvchad =
-            flake-utils.lib.mkApp {
-              drv = self.packages.${system}.nvchad;
-              name = "nvim";
-            }
-            # ? workaround add meta attrs to avoid warning message
-            // {
-              meta = self.packages.${system}.nvchad.meta;
-            };
-          default = nvchad;
+      });
+
+      homeManagerModules =
+        let
+          nvchadModule = import ./nix/module.nix {
+            starterRepo = nvchad-starter;
+          };
+        in
+        {
+          nvchad = nvchadModule;
+          default = nvchadModule;
         };
-        checks = self.packages.${system};
-        devShells.default = pkgs.mkShell {
-          buildInputs = [ pkgs.mdbook ];
-        };
-      }
-    )
-    // {
-      homeManagerModules = rec {
-        nvchad = import ./nix/module.nix { starterRepo = nvchad-starter; };
-        default = nvchad;
-      };
+
       # DEPRECATED: This attribute will be removed soon.
       # Use homeManagerModules.default instead.
       homeManagerModule = self.homeManagerModules.nvchad;


### PR DESCRIPTION
Replace flake-utils with an explicit list of supported systems.
Keep Intel macOS available as a best-effort Home Manager workaround.