### PR TITLE
refactor(flake)!: remove deprecated homeManagerModule output

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,21 @@ Want to see it in action without installing? You can run it directly:
 nix run github:nix-community/nix4nvchad
 ```
 
-> [!WARNING]  
-> If you already have an existing Neovim configuration at `~/.config/nvim`, this command will create a backup before launching. Make sure your environment is safe.
+> [!NOTE]
+> When NvChad needs to initialize `~/.config/nvim`, an existing directory
+> is moved to a timestamped backup such as
+> `~/.config/nvim_2026_07_27_14_30_00.bak`.
 
 ## Intel macOS
 
-`x86_64-darwin` is not included in the officially tested flake outputs
-because current Nixpkgs releases no longer support Intel macOS. Commands
-such as the following are therefore unsupported on Intel Macs:
+Official `x86_64-darwin` support was removed because Nixpkgs unstable no
+longer supports Intel macOS. Nixpkgs 26.05 is the last release to support
+the platform. The removal landed in an [upstream Nixpkgs commit][upstream]
+and was followed by a [nix-community announcement][announcement].
+
+Consequently, `x86_64-darwin` is not included in the officially tested
+flake outputs. Commands such as the following are unsupported on Intel
+Macs:
 
 ```console
 nix run github:nix-community/nix4nvchad
@@ -99,6 +106,11 @@ This works because the module builds the package with the user's `pkgs`.
 It does not add `packages.x86_64-darwin` or `apps.x86_64-darwin` to
 nix4nvchad itself. This workaround is best effort and is not tested by
 the project's CI.
+
+[upstream]:
+  https://github.com/NixOS/nixpkgs/commit/90796a2
+[announcement]:
+  https://github.com/orgs/nix-community/discussions/2195
 
 ## Usage Guide
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,4 +6,4 @@
 - [Advanced Usage](advanced_usage.md)
 
 ---
-- [Deprecated](deprecated.md)
+- [Removed features](deprecated.md)

--- a/docs/src/deprecated.md
+++ b/docs/src/deprecated.md
@@ -1,39 +1,50 @@
-# Deprecated Features
+# Removed features
 
-This page lists features, attributes, or configuration options that are currently deprecated and slated for removal in future versions of `nix4nvchad`.
+This page documents removed features and their available migration paths.
 
-## `homeManagerModule` Attribute
+## `homeManagerModule` attribute
 
-The flake output attribute `inputs.nix4nvchad.homeManagerModule` is **deprecated** and will be removed in the near future. 
+The deprecated singular flake output
+`inputs.nix4nvchad.homeManagerModule` has been removed. Use
+`homeManagerModules.default` instead.
 
-### Why is it being removed?
+Before:
 
-In the Nix flake ecosystem, Home Manager modules exported by a flake are inherently non-standard (unlike NixOS or nix-darwin modules). The standard and most widely accepted way to export these is under the `homeManagerModules` (plural) attribute, typically exposing the default module as `homeManagerModules.default`.
-
-Maintaining the singular `homeManagerModule` attribute is redundant, creates unnecessary aliases in the flake output, and can trigger validation warnings in some Nix checking tools.
-
-### What should you use instead?
-
-You should update your imports to use the standard `homeManagerModules.default` path.
-
-**❌ Deprecated:**
 ```nix
-{ inputs, pkgs, ... }: {
-  imports = [
-    inputs.nix4nvchad.homeManagerModule
-  ];
-  
+{ inputs, ... }: {
+  imports = [ inputs.nix4nvchad.homeManagerModule ];
+
   programs.nvchad.enable = true;
 }
 ```
 
-**✅ Recommended:**
+After:
+
 ```nix
-{ inputs, pkgs, ... }: {
-  imports = [
-    inputs.nix4nvchad.homeManagerModules.default
-  ];
-  
+{ inputs, ... }: {
+  imports = [ inputs.nix4nvchad.homeManagerModules.default ];
+
   programs.nvchad.enable = true;
 }
 ```
+
+## Intel macOS support
+
+Official `x86_64-darwin` support has been removed from nix4nvchad.
+Nixpkgs 26.05 is the last release to support Intel macOS. Nixpkgs
+unstable removed the platform after the 26.05 branch was created, so it
+can no longer be evaluated by nix4nvchad's unstable Nixpkgs input.
+
+The change is documented in the
+[nix-community announcement][announcement] and the corresponding
+[upstream Nixpkgs commit][upstream].
+
+The Home Manager module may still work as a best-effort workaround when
+the user's configuration supplies `pkgs` from the final supported Nixpkgs
+branch. This does not restore `x86_64-darwin` flake outputs and is not
+tested by the project's CI.
+
+[announcement]:
+  https://github.com/orgs/nix-community/discussions/2195
+[upstream]:
+  https://github.com/NixOS/nixpkgs/commit/90796a2

--- a/flake.nix
+++ b/flake.nix
@@ -90,9 +90,5 @@
           nvchad = nvchadModule;
           default = nvchadModule;
         };
-
-      # DEPRECATED: This attribute will be removed soon.
-      # Use homeManagerModules.default instead.
-      homeManagerModule = self.homeManagerModules.nvchad;
     };
 }


### PR DESCRIPTION
Document the removal and the end of official Intel macOS support.

BREAKING CHANGE: The homeManagerModule flake output has been removed. Use homeManagerModules.default instead.